### PR TITLE
Add support for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*"
+        "laravel/framework": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",


### PR DESCRIPTION
# Description

This PR add support for Laravel 6.0 released on Septembre 6th, 2019.