### PR TITLE
feat: support Laravel 11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [8.1, 8.2, 8.3]
-        laravel: [10.*]
+        laravel: [10.*, 11.*]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,9 @@ jobs:
         php: [8.1, 8.2, 8.3]
         laravel: [10.*, 11.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 8.1
+            laravel: 11.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3]
         laravel: [10.*, 11.*]
         dependency-version: [prefer-lowest, prefer-stable]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "laravel/framework": "^10.0"
+        "laravel/framework": "^10.0|^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^9.3.3",
+        "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.3",
         "squizlabs/php_codesniffer": "^3.6"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "8.2.*|8.3.*",
         "laravel/framework": "^10.0|^11.0"
     },
     "require-dev": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         beStrictAboutTestsThatDoNotTestAnything="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+>
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>


### PR DESCRIPTION
Update [laravel-emails-confirmation](https://github.com/eXolnet/laravel-emails-confirmation) to support Laravel 11. 
Update php requirements to "`8.2 | 8.3`"

Deprecate `Php 8.1` to support `PhpUnit 11.*`

Adjust some unit tests using deprecated methods